### PR TITLE
Aktualisierung import LookAndFeel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+.idea/
 pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup

--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,10 @@
 	<name>Struktogrammeditor</name>
 
 	<properties>
-    	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  	</properties>
+  	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
 
 	<scm>
 		<url>https://github.com/kekru/struktogrammeditor</url>

--- a/src/main/java/de/kekru/struktogrammeditor/control/Controlling.java
+++ b/src/main/java/de/kekru/struktogrammeditor/control/Controlling.java
@@ -22,7 +22,7 @@ import javax.swing.LookAndFeel;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 
-import com.sun.java.swing.plaf.motif.MotifLookAndFeel;
+import javax.swing.plaf.metal.MetalLookAndFeel;
 import javax.swing.plaf.nimbus.NimbusLookAndFeel;
 
 import de.kekru.struktogrammeditor.other.Helpers;
@@ -81,7 +81,7 @@ public class Controlling implements Konstanten, ActionListener, WindowListener, 
 				lookAndFeel = new NimbusLookAndFeel();
 				break;
 
-			case lookAndFeelMotif: lookAndFeel = new MotifLookAndFeel();
+			case lookAndFeelMotif: lookAndFeel = new MetalLookAndFeel();
 			break;
 			}
 


### PR DESCRIPTION
War Deprecated ab Java 13

Download: https://javadoc.jitpack.io/com/github/kekru/struktogrammeditor/feature~update-deprecated-laf-a0ca18a7fe-1/struktogrammeditor-feature~update-deprecated-laf-a0ca18a7fe-1-jar-with-dependencies.jar